### PR TITLE
Handle required attributes for hidden fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: optimizely, ab testing, split testing, website optimization
 Requires at least: 3.0
 Tested up to: 4.4
 Donate link: N/A
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: BSD 3-Clause
 License URI: https://opensource.org/licenses/BSD-3-Clause
 
@@ -31,6 +31,9 @@ Sign up at [Optimizely.com](http://www.optimizely.com).
 You're ready to start using Optimizely!
 
 == Changelog ==
+
+= 1.1.1 =
+* Fixed a bug where some required fields were hidden.
 
 = 1.1.0 =
 * Increased the timeout of all requests to the Optimizely API to 60 seconds

--- a/admin/js/metabox.js
+++ b/admin/js/metabox.js
@@ -100,7 +100,7 @@
 				// Swap the new experiment block for the loading block.
 				$( '.optimizely-loading' ).removeClass( 'hidden' );
 				$( '.optimizely-new-experiment' ).addClass( 'hidden' );
-				$( 'optimizely-variation input' ).removeAttr( 'required' );
+				$( '.optimizely-variation input' ).removeAttr( 'required' );
 
 				// Send the variation data via AJAX.
 				$.ajax( {
@@ -122,7 +122,7 @@
 					if ( ! response.success ) {
 						OptimizelyMetabox.showError( optimizely_metabox_strings.experiment_error );
 						$( '.optimizely-new-experiment' ).removeClass( 'hidden' );
-						$( 'optimizely-variation input' ).attr( 'required', true );
+						$( '.optimizely-variation input' ).attr( 'required', true );
 						return;
 					}
 

--- a/admin/js/metabox.js
+++ b/admin/js/metabox.js
@@ -100,6 +100,7 @@
 				// Swap the new experiment block for the loading block.
 				$( '.optimizely-loading' ).removeClass( 'hidden' );
 				$( '.optimizely-new-experiment' ).addClass( 'hidden' );
+				$( 'optimizely-variation input' ).removeAttr( 'required' );
 
 				// Send the variation data via AJAX.
 				$.ajax( {
@@ -121,6 +122,7 @@
 					if ( ! response.success ) {
 						OptimizelyMetabox.showError( optimizely_metabox_strings.experiment_error );
 						$( '.optimizely-new-experiment' ).removeClass( 'hidden' );
+						$( 'optimizely-variation input' ).attr( 'required', true );
 						return;
 					}
 

--- a/admin/partials/metabox.php
+++ b/admin/partials/metabox.php
@@ -42,7 +42,7 @@ if ( empty( $post_num_variations ) ) {
 						name="<?php echo esc_attr( $meta_key ); ?>"
 						placeholder="<?php esc_attr_e( 'Title', 'optimizely-x' ); ?> <?php echo absint( $i ); ?>"
 						type="text"
-						required
+						<?php echo empty( $experiment_id ) ? 'required' : ''; ?>
 					/>
 				</div>
 			<?php endfor; ?>

--- a/optimizely-x.php
+++ b/optimizely-x.php
@@ -14,7 +14,7 @@
  * Plugin Name: Optimizely X
  * Plugin URI: https://wordpress.org/plugins/optimizely-x/
  * Description: Simple, fast, and powerful. <a href="https://www.optimizely.com">Optimizely</a> is a dramatically easier way for you to improve your website through A/B testing. Create an experiment in minutes with our easy-to-use visual interface with absolutely no coding or engineering required. Convert your website visitors into customers and earn more revenue today! To get started: 1) Click the "Activate" link to the left of this description, 2) Sign up for an <a href="https://www.optimizely.com">Optimizely account</a>, and 3) Create an API Token here: <a href="https://www.optimizely.com/tokens">API Tokens</a>, and enter your API token in the Configuration Tab of the Plugin, then select a project to start testing!
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Optimizely
  * Author URI: https://www.optimizely.com
  * License: GPL-2.0+


### PR DESCRIPTION
Removes the `required` attribute on the input fields when the experiment is created and they are hidden. Also prevents the `required` attribute from being added when an experiment id exists.