### PR TITLE
Opt-6 and Opt-12 - Bug Fixes and VIP Suggestions

### DIFF
--- a/admin/js/metabox.js
+++ b/admin/js/metabox.js
@@ -36,7 +36,13 @@
 
 					// Handle error state.
 					if ( ! response.success ) {
-						OptimizelyMetabox.showError( optimizely_metabox_strings.status_error );
+						if ( response.data[0]['message'] ) {
+							OptimizelyMetabox.showError( response.data[0]['message'] );
+						} else if ( response.data.length ) {
+							OptimizelyMetabox.showError( response.data );
+						} else {
+							OptimizelyMetabox.showError( optimizely_metabox_strings.status_error );
+						}
 						return;
 					}
 
@@ -119,7 +125,13 @@
 
 					// Handle error state.
 					if ( ! response.success ) {
-						OptimizelyMetabox.showError( optimizely_metabox_strings.experiment_error );
+						if ( response.data[0]['message'] ) {
+							OptimizelyMetabox.showError( response.data[0]['message'] );
+						} else if ( response.data.length ) {
+							OptimizelyMetabox.showError( response.data );
+						} else {
+							OptimizelyMetabox.showError( optimizely_metabox_strings.experiment_error );
+						}
 						$( '.optimizely-new-experiment' ).removeClass( 'hidden' );
 						return;
 					}

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -39,11 +39,11 @@ JAVASCRIPT;
 var utils = window['optimizely'].get('utils');
 utils.waitForElement( '.post-\$POST_ID h1' ).then( function () {
     var element = document.querySelector( '.post-\$POST_ID h1' );
-    element.innerHTML = '\$NEW_TITLE';
+    element.innerText = '\$NEW_TITLE';
 } );
 utils.waitForElement( '.post-\$POST_ID h3 a' ).then( function () {
     var element = document.querySelector( '.post-\$POST_ID h3 a' );
-    element.innerHTML = '\$NEW_TITLE';
+    element.innerText = '\$NEW_TITLE';
 } );
 JAVASCRIPT;
 
@@ -126,15 +126,17 @@ JAVASCRIPT;
 			return;
 		}
 
-		// Add the meta box.
-		add_meta_box(
-			'optimizely-headlines',
-			esc_html__( 'A/B Test Headlines', 'optimizely-x' ),
-			array( $this, 'metabox_headlines_render' ),
-			get_post_type(),
-			'side',
-			'high'
-		);
+		if ( current_user_can( Filters::admin_capability() ) ) {
+			// Add the meta box.
+			add_meta_box(
+				'optimizely-headlines',
+				esc_html__( 'A/B Test Headlines', 'optimizely-x' ),
+				array( $this, 'metabox_headlines_render' ),
+				get_post_type(),
+				'side',
+				'high'
+			);
+		}
 	}
 
 	/**

--- a/includes/class-ajax-metabox.php
+++ b/includes/class-ajax-metabox.php
@@ -65,6 +65,7 @@ class AJAX_Metabox extends AJAX {
 
 		// Process the request and check for errors.
 		$response = $this->api->patch( $operation );
+		$this->log_request( $post_id, 'PATCH', $operation, array(), $response );
 		$this->maybe_send_error_response( $response );
 
 		// Ensure we got a status in the response.
@@ -172,13 +173,13 @@ class AJAX_Metabox extends AJAX {
 		}
 
 		// Try to create an experiment for this post.
-		$experiment_id = $this->build_experiment(
+		$experiment_id = absint( $this->build_experiment(
 			$project_id,
 			$post,
 			$variations,
 			$targeting_id,
 			$event_id
-		);
+		) );
 		if ( empty( $experiment_id ) ) {
 			wp_send_json_error( __(
 				'An error occurred during the creation of an event page.',
@@ -194,28 +195,28 @@ class AJAX_Metabox extends AJAX {
 		);
 
 		// Store the editor link in postmeta.
-		add_post_meta(
+		update_post_meta(
 			$post->ID,
 			'optimizely_editor_link',
 			esc_url_raw( $editor_link )
 		);
 
 		// Store the experiment ID in postmeta.
-		add_post_meta(
+		update_post_meta(
 			$post->ID,
 			'optimizely_experiment_id',
 			absint( $experiment_id )
 		);
 
 		// Store the experiment status in postmeta.
-		add_post_meta(
+		update_post_meta(
 			$post->ID,
 			'optimizely_experiment_status',
 			'not_started'
 		);
 
 		// Store the number of variations in postmeta.
-		add_post_meta(
+		update_post_meta(
 			$post->ID,
 			'optimizely_variations_num',
 			count( $variations )
@@ -224,7 +225,7 @@ class AJAX_Metabox extends AJAX {
 		// Loop over variations and store each in postmeta.
 		$total_variations = count( $variations );
 		for ( $i = 0; $i < $total_variations; $i ++ ) {
-			add_post_meta(
+			update_post_meta(
 				$post->ID,
 				sprintf( 'optimizely_variations_%d', absint( $i ) ),
 				sanitize_text_field( $variations[ $i ] )
@@ -311,6 +312,7 @@ class AJAX_Metabox extends AJAX {
 
 		// Get the API response and check for errors.
 		$response = $this->api->post( '/pages', $event_page );
+		$this->log_request( $post->ID, 'POST', '/pages', $event_page, $response );
 		$this->maybe_send_error_response( $response );
 
 		// Ensure we got an ID.
@@ -384,6 +386,7 @@ class AJAX_Metabox extends AJAX {
 
 		// Get the API response and check for errors.
 		$response = $this->api->post( '/experiments', $experiment, true );
+		$this->log_request( $post->ID, 'POST', '/experiments', $experiment, $response );
 		$this->maybe_send_error_response( $response );
 
 		// Ensure we got an ID.
@@ -472,6 +475,7 @@ class AJAX_Metabox extends AJAX {
 
 		// Get the API response and check for errors.
 		$response = $this->api->post( '/pages', $targeting_page );
+		$this->log_request( $post->ID, 'POST', '/pages', $targeting_page, $response );
 		$this->maybe_send_error_response( $response );
 
 		// Ensure we got an ID.
@@ -498,9 +502,9 @@ class AJAX_Metabox extends AJAX {
 
 		// Load the variation template and swap out dynamic values.
 		$template = get_option( 'optimizely_x_variation_template' );
-		$template = str_replace( '$POST_ID', $post->ID, $template );
-		$template = str_replace( '$NEW_TITLE', $title, $template );
-		$template = str_replace( '$OLD_TITLE', $post->post_title, $template );
+		$template = str_replace( '$POST_ID', absint( $post->ID ), $template );
+		$template = str_replace( '$NEW_TITLE', esc_js( $title ), $template );
+		$template = str_replace( '$OLD_TITLE', esc_js( $post->post_title ), $template );
 
 		return array(
 			'actions' => array(

--- a/includes/class-ajax-results.php
+++ b/includes/class-ajax-results.php
@@ -56,13 +56,16 @@ class AJAX_Results extends AJAX {
 
 		// Ensure we have a post ID before proceeding.
 		$query_args = [
-			'meta_key' => 'optimizely_experiment_id', // Potentialy slow query
-			'meta_value' => $experiment_id, // Potentialy slow query
+			'meta_key'      => 'optimizely_experiment_id', // Potentialy slow query
+			'meta_value'    => $experiment_id, // Potentialy slow query
+			'post_type'     => 'any',
+			'no_found_rows' => true,
+			'posts_per_page' => 1,
 		];
 
 		$experiment_query = new \WP_Query( $query_args );
 
-		if ( ! $experiment_query->found_posts ) {
+		if ( ! $experiment_query->post_count ) {
 			wp_send_json_error( __( 'Missing a post attached to this experiment.', 'optimizely-x' ) );
 		}
 
@@ -140,11 +143,14 @@ class AJAX_Results extends AJAX {
 		$query_args = [
 			'meta_key' => 'optimizely_experiment_id', // Potential slow query
 			'meta_value' => $experiment_id, // Potential slow query
+			'post_type' => 'any',
+			'no_found_rows' => true,
+			'posts_per_page' => 1,
 		];
 
 		$experiment_query = new \WP_Query( $query_args );
 
-		if ( ! $experiment_query->found_posts ) {
+		if ( ! $experiment_query->post_count ) {
 			wp_send_json_error( __( 'Missing a post attached to this experiment.', 'optimizely-x' ) );
 		}
 
@@ -221,11 +227,14 @@ class AJAX_Results extends AJAX {
 		$query_args = [
 			'meta_key' => 'optimizely_experiment_id', // Potential slow query
 			'meta_value' => $experiment_id, // Potential slow query
+			'post_type' => 'any',
+			'no_found_rows' => true,
+			'posts_per_page' => 1,
 		];
 
 		$experiment_query = new \WP_Query( $query_args );
 
-		if ( ! $experiment_query->found_posts ) {
+		if ( ! $experiment_query->post_count ) {
 			wp_send_json_error( __( 'Missing a post attached to this experiment.', 'optimizely-x' ) );
 		}
 

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -45,6 +45,12 @@ abstract class AJAX {
 	 */
 	protected function maybe_send_error_response( $response ) {
 
+		// Handle WP_Errors.
+		if ( is_wp_error( $response ) ) {
+			wp_send_json_error( $response );
+		}
+
+		// Handle other errors.
 		// If the operation was successful, don't send an error.
 		if ( ! empty( $response['status'] ) && 'SUCCESS' === $response['status'] ) {
 			return;
@@ -57,5 +63,27 @@ abstract class AJAX {
 
 		// Send the error data in the response.
 		wp_send_json_error( sanitize_text_field( $response['error'] ) );
+	}
+
+	/**
+	 * Log API request and response to post meta.
+	 * Purpose is debugging response errors and providing diagnostic data to Optimizely.
+	 *
+	 * @param int $post_id Post ID to save the meta to.
+	 * @param string $method The HTTP method.
+	 * @param string $operation The operation URL endpoint.
+	 * @param array $data Data included in the request.
+	 * @param WP_Error\array $response Response from the API request method.
+	 *                                 Either an error, object, or array.
+	 */
+	protected function log_request( $post_id, $method, $operation, $data, $response ) {
+		$log_meta_key = '_optimizely_request_log';
+		add_post_meta( $post_id, $log_meta_key, array(
+			'method' => $method,
+			'operation' => $operation,
+			'data' => $data,
+			'response' => (array) $response,
+			'time' => date( 'M j, Y, g:i a T', current_time( 'timestamp' ) ),
+		) );
 	}
 }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -224,7 +224,10 @@ class API {
 		if ( $extended_timeout ) {
 			$timeout = 60;
 		} else {
-			$timeout = 5;
+			// Temporarily set all requests to 60 second timeout.
+			// Until cause of long API responses is fixed.
+			// See VIP Zendesk Ticket z-86051
+			$timeout = 60;
 		}
 
 		// If the provided operation is a partial path, convert to a full URL.
@@ -306,7 +309,7 @@ class API {
 		// If this is an error, return that.
 		// Timeout errors will be caught here.
 		if ( is_wp_error( $response ) ) {
-			return wp_send_json_error( $response );
+			return $response;
 		} else {
 			// Build result object.
 			$result = array(

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -303,36 +303,52 @@ class API {
 				);
 		} // End switch().
 
-		// Build result object.
-		$result = array(
-			'body' => wp_remote_retrieve_body( $response ),
-			'code' => absint( wp_remote_retrieve_response_code( $response ) ),
-			'error' => array(),
-			'headers' => wp_remote_retrieve_headers( $response ),
-			'json' => json_decode( wp_remote_retrieve_body( $response ), true ),
-		);
+		// If this is an error, return that.
+		// Timeout errors will be caught here.
+		if ( is_wp_error( $response ) ) {
+			return wp_send_json_error( $response );
+		} else {
+			// Build result object.
+			$result = array(
+				'body' => wp_remote_retrieve_body( $response ),
+				'code' => absint( wp_remote_retrieve_response_code( $response ) ),
+				'error' => array(),
+				'headers' => wp_remote_retrieve_headers( $response ),
+				'json' => json_decode( wp_remote_retrieve_body( $response ), true ),
+			);
 
-		// Handle rate limiting.
-		if ( 429 === $result['code'] ) {
-			$wait_time = wp_remote_retrieve_header( $response, 'X-RATELIMIT-RESET' );
-			usleep( $wait_time );
+			// Handle rate limiting.
+			if ( 429 === $result['code'] ) {
+				$wait_time = wp_remote_retrieve_header( $response, 'X-RATELIMIT-RESET' );
+				usleep( (int) $wait_time );
 
-			return $this->request( $method, $url, $data );
+				return $this->request( $method, $url, $data );
+			}
+
+			// Check for errors.
+			if ( empty( $response )
+				|| ! is_array( $response )
+				|| is_wp_error( $response )
+				|| $result['code'] < 200
+				|| $result['code'] > 204
+			) {
+				$result['status'] = 'ERROR';
+
+				// Provide a message for the caller to handle. @see maybe_send_error_response
+				if ( ! empty( $result['code'] ) ) {
+					$result['error'] = sprintf(
+						'HTTP Response Code %d for %s: %s',
+						esc_html( $result['code'] ),
+						esc_html( $method ),
+						esc_html( $url )
+					);
+				}
+			} else {
+				// Add success status to response.
+				$result['status'] = 'SUCCESS';
+			}
+
+			return $result;
 		}
-
-		// Check for errors.
-		if ( empty( $response )
-			|| ! is_array( $response )
-			|| is_wp_error( $response )
-			|| $result['code'] < 200
-			|| $result['code'] > 204
-		) {
-			$result['status'] = 'ERROR';
-		}
-
-		// Add success status to response.
-		$result['status'] = 'SUCCESS';
-
-		return $result;
 	}
 }

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -24,7 +24,7 @@ class Core {
 	 * @since 1.0.0
 	 * @var string
 	 */
-	const VERSION = '1.2.0';
+	const VERSION = '1.2.1';
 
 	/**
 	 * Initialize the objects that control the plugin's functionality.


### PR DESCRIPTION
This fixes a variety of bugs and improves security.

- Fix an issue where experiments couldn't be launched because multiple experiment IDs and empty experiment IDs were being added to a post.
-  Fix bug where launching an experiment didn't work for custom post types.
- Escape headline variation text for output in javascript and use innerText instead of innerHTML to prevent javascript injection.
- Only display the metabox to users with the Optimizely capability.
- Improve performance of WordPress meta queries.
- Log API requests and responses to post meta to allow for determining cause of API failures and other issues.
- Increase all requests to 60 second timeout to handle long server response times.
- Improve the error messages that are displayed to the user.